### PR TITLE
Make server array ID optional parameter. 

### DIFF
--- a/bin/rs-get-server-array.sh
+++ b/bin/rs-get-server-array.sh
@@ -2,14 +2,14 @@
 
 # rs-get-server-array <server_array_id>
 
-[[ ! $1 ]] && echo 'No server array ID provided, exiting.' && exit 1
-
 . "$HOME/.rightscale/rs_api_config.sh"
 . "$HOME/.rightscale/rs_api_creds.sh"
 
-array_id="$1"
+if [ "$1" ]; then
+     array_id="/$1"
+fi
 
-url="https://my.rightscale.com/api/acct/$rs_api_account_id/server_arrays/$array_id"
+url="https://my.rightscale.com/api/acct/$rs_api_account_id/server_arrays$array_id"
 echo "GET: $url"
 api_result=$(curl -s -H "X-API-VERSION: $rs_api_version" -b "$rs_api_cookie" "$url")
 echo "$api_result"


### PR DESCRIPTION
This just follows the behaviour in other scripts which allows the get array call without an ID to return a list of all server arrays.
